### PR TITLE
load assignment psets

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "commander": "^10.0.0",
     "filenamify": "^5.1.1",
     "fs-extra": "^11.1.1",
+    "jsdom": "20.0.0",
     "lodash": "^4.17.21",
     "superagent": "^8.0.9"
   },


### PR DESCRIPTION
Opening this PR just in case you'd want this contribution to basically download the problem sets in the assignment folder, by going through the files listed there. Probably would need to clean up some stuff and the jsdom dependency can probably be replaced by a better regex. basically for me courses have files in their assignments descriptions, so this fixes that hole. Feel free to ignore too.
Best